### PR TITLE
fix: handle fully reserved capacity

### DIFF
--- a/pool_test.go
+++ b/pool_test.go
@@ -15,6 +15,7 @@ const (
 	catA cat = iota
 	catB
 	catC
+	catD
 )
 
 /* ------------------------------------------------------------------
@@ -217,4 +218,19 @@ func TestReleaseWithZeroUsagePanics(t *testing.T) {
 	}()
 	p := New(1, map[int]int{0: 1})
 	p.Release(0)
+}
+
+/* ------------------------------------------------------------------
+   8. Acquire should fail when capacity is fully reserved
+-------------------------------------------------------------------*/
+
+func TestAcquireWhenFullyReserved(t *testing.T) {
+	p := New(4, map[cat]int{catA: 2, catB: 2, catC: 0})
+
+	if err := p.Acquire(catC); !errors.Is(err, ErrUnsatisfiable) {
+		t.Fatalf("expected error: %v, got: %v", ErrUnsatisfiable, err)
+	}
+	if err := p.Acquire(catD); !errors.Is(err, ErrUnsatisfiable) {
+		t.Fatalf("expected error: %v, got: %v", ErrUnsatisfiable, err)
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/guillaumemichel/reservedpool/issues/1

If all capacity is reserved, `Acquire` returns an error for categories without a reservation.

cc: @gammazero